### PR TITLE
Feature/tiny url

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,8 @@ install:
 - docker network create --subnet=172.18.0.0/16 travisnet
 # Create a docker container with a specific IP that travis can connect to during testing
 - docker run -d --net travisnet --ip 172.18.0.22 quay.io/garyluu/jenkins
+# Sleep for 20 seconds while jenkins loads
+- 'sleep 20'
 # Build and run tests
 - cd tooltester && mvn -B clean install -DskipITs=false cobertura:cobertura coveralls:report
 

--- a/tooltester/src/main/java/io/dockstore/tooltester/client/cli/Client.java
+++ b/tooltester/src/main/java/io/dockstore/tooltester/client/cli/Client.java
@@ -44,6 +44,7 @@ import io.dockstore.tooltester.helper.TimeHelper;
 import io.dockstore.tooltester.jenkins.OutputFile;
 import io.dockstore.tooltester.report.FileReport;
 import io.dockstore.tooltester.report.StatusReport;
+import io.dockstore.tooltester.helper.TinyUrl;
 import io.swagger.client.ApiClient;
 import io.swagger.client.ApiException;
 import io.swagger.client.Configuration;
@@ -494,8 +495,8 @@ public class Client {
                             for (PipelineStepImpl pipelineStep : pipelineSteps) {
                                 runtime += pipelineStep.getDurationInMillis();
                                 if (!state.equals("RUNNING") && pipelineStep.getResult().equals("FAILURE")) {
-                                    result += " See " + serverUrl + pipelineStep.getActions().get(0).getLinks().getSelf().getHref()
-                                            .replaceFirst("^/", "");
+                                    result += " See " + TinyUrl.getTinyUrl(serverUrl + pipelineStep.getActions().get(0).getLinks().getSelf().getHref()
+                                            .replaceFirst("^/", ""));
                                 }
                             }
                             String date = pipelineNode.getStartTime();

--- a/tooltester/src/main/java/io/dockstore/tooltester/helper/TinyUrl.java
+++ b/tooltester/src/main/java/io/dockstore/tooltester/helper/TinyUrl.java
@@ -1,0 +1,26 @@
+package io.dockstore.tooltester.helper;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.net.URL;
+
+/**
+ * @author gluu
+ * @since 15/03/17
+ */
+
+public class TinyUrl {
+    private static final String TINY_URL = "http://tinyurl.com/api-create.php?url=";
+
+    public static String getTinyUrl(String longUrl) {
+        String tinyUrlLookup = TINY_URL + longUrl;
+        try {
+            BufferedReader reader = new BufferedReader(new InputStreamReader(new URL(tinyUrlLookup).openStream(), "UTF-8"));
+            return reader.readLine();
+        } catch (IOException e) {
+            e.printStackTrace();
+            return longUrl;
+        }
+    }
+}

--- a/tooltester/src/main/java/io/dockstore/tooltester/report/StatusReport.java
+++ b/tooltester/src/main/java/io/dockstore/tooltester/report/StatusReport.java
@@ -9,7 +9,7 @@ import java.util.List;
  */
 public class StatusReport extends Report {
     private static final List<String> HEADER = Arrays
-            .asList("Tool/Workflow ID", "DATE", "Version", "Location of testing", "Action Performed", "Runtime", "Status of Test Files");
+            .asList("Tool/Workflow ID", "DATE", "Version", "Location of Testing", "Action Performed", "Runtime", "Status of Test Files");
 
     public StatusReport(String name) {
         super(name);

--- a/tooltester/src/test/java/io/dockstore/tooltester/client/cli/ClientTest.java
+++ b/tooltester/src/test/java/io/dockstore/tooltester/client/cli/ClientTest.java
@@ -192,7 +192,7 @@ public class ClientTest {
         Assert.assertTrue(systemOutRule.getLog().contains("Tool/Workflow ID"));
         Assert.assertTrue(systemOutRule.getLog().contains("DATE"));
         Assert.assertTrue(systemOutRule.getLog().contains("Version"));
-        Assert.assertTrue(systemOutRule.getLog().contains("Location of testing"));
+        Assert.assertTrue(systemOutRule.getLog().contains("Location of Testing"));
         Assert.assertTrue(systemOutRule.getLog().contains("Action Performed"));
         Assert.assertTrue(systemOutRule.getLog().contains("Runtime"));
         Assert.assertTrue(systemOutRule.getLog().contains("Status of Test Files"));

--- a/tooltester/src/test/java/io/dockstore/tooltester/client/cli/JenkinsJobTest.java
+++ b/tooltester/src/test/java/io/dockstore/tooltester/client/cli/JenkinsJobTest.java
@@ -63,6 +63,7 @@ public class JenkinsJobTest {
         exit.expectSystemExitWithStatus(10);
         client.setupTesters();
         PipelineTester pipelineTester = client.getPipelineTester();
+        Assert.assertTrue("Jenkins server can not be reached", pipelineTester.getJenkins() != null);
         pipelineTester.getTestResults("SuffixOfATestThatShouldNotExist");
     }
 }

--- a/tooltester/src/test/java/io/dockstore/tooltester/helper/TinyUrlTest.java
+++ b/tooltester/src/test/java/io/dockstore/tooltester/helper/TinyUrlTest.java
@@ -1,0 +1,18 @@
+package io.dockstore.tooltester.helper;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+/**
+ * @author gluu
+ * @since 16/03/17
+ */
+public class TinyUrlTest {
+    @Test
+    public void getTinyUrl() throws Exception {
+        String tinyUrl = TinyUrl.getTinyUrl("https://www.google.ca");
+        assertTrue(tinyUrl.equals("http://tinyurl.com/d4gfaxc"));
+    }
+
+}


### PR DESCRIPTION
Changing Jenkins log to use tinyUrl to shorten the length.  Fix for Travis not setting Jenkins up fast enough.