### PR TITLE
Remove ga4gh-dream from s3 cache since it is used for others as well

### DIFF
--- a/tooltester/src/main/java/io/dockstore/tooltester/helper/GA4GHHelper.java
+++ b/tooltester/src/main/java/io/dockstore/tooltester/helper/GA4GHHelper.java
@@ -8,19 +8,19 @@ public class GA4GHHelper {
     public static String mapRepositoryToCache(String repository) {
         switch(repository) {
         case "briandoconnor/dockstore-workflow-md5sum":
-            return "md5sum";
+            return "ga4gh-dream/md5sum";
         case "dockstore/hello_world":
-            return "hello_world";
+            return "ga4gh-dream/hello_world";
         case "Barski-lab/biowardrobe_chipseq_se":
-            return "biowardrobe";
+            return "ga4gh-dream/biowardrobe";
         case "NCI-GDC/gdc-dnaseq-cwl/GDC_DNASeq":
-            return "gdc";
+            return "ga4gh-dream/gdc";
         case "bcbio/bcbio_validation_workflows":
-            return "bcbio";
+            return "ga4gh-dream/bcbio";
         case "ENCODE-DCC/pipeline-container/encode-mapping-cwl":
-            return "encode";
+            return "ga4gh-dream/encode";
         case "knowengplaceholder":
-            return "knoweng";
+            return "ga4gh-dream/knoweng";
         default:
             return "";
         }

--- a/tooltester/src/main/resources/PipelineTest.groovy
+++ b/tooltester/src/main/resources/PipelineTest.groovy
@@ -28,7 +28,7 @@ def transformIntoStep(url, tag, descriptor, parameter, entryType, synapseCache) 
                 dir('target') {
                     sh 'git checkout ${Tag}'
                     if (synapseCache != "") {
-                        sh 's3cmd get --skip-existing --recursive s3://dockstore/test_files/ga4gh-dream/${SynapseCache}/'
+                        sh 's3cmd get --skip-existing --recursive s3://dockstore/test_files/${SynapseCache}/'
                     }
                     sh 'echo dockstore ${entryType} launch --local-entry ${descriptor} --json ${parameter} --script'
                     FILE = sh (script: "set -o pipefail && dockstore $entryType launch --local-entry $descriptor --json $parameter --script | tee /dev/stderr | sed -n -e 's/^.*Saving copy of cwltool stdout to: //p'", returnStdout: true).trim()


### PR DESCRIPTION
Generalize the s3 cache path so other non-ga4gh-dream workflows can also have a cache