### PR TITLE
Feature/rabix config

### DIFF
--- a/tooltester/src/main/java/io/dockstore/tooltester/helper/DockstoreConfigHelper.java
+++ b/tooltester/src/main/java/io/dockstore/tooltester/helper/DockstoreConfigHelper.java
@@ -5,10 +5,6 @@ package io.dockstore.tooltester.helper;
  * @since 05/12/17
  */
 public class DockstoreConfigHelper {
-    public enum CWLRUNNER {
-        CWLTOOL,
-        RABIX
-    }
     private static String baseConfig(String url) {
         return "token: test \\nserver-url: " + url;
     }
@@ -20,15 +16,15 @@ public class DockstoreConfigHelper {
         return baseConfig(url) + "\\ncwlrunner: bunny";
     }
 
-    public static String getConfig(String url, CWLRUNNER runner) {
+    public static String getConfig(String url, String runner) {
         switch (runner) {
-        case CWLTOOL:
+        case "cwltool":
             return cwltoolConfig(url);
-        case RABIX:
+        case "bunny":
             return rabixConfig(url);
         default:
             ExceptionHandler.errorMessage("Unknown runner.", ExceptionHandler.CLIENT_ERROR);
         }
-        return null;
+        return cwltoolConfig(url);
     }
 }

--- a/tooltester/src/main/java/io/dockstore/tooltester/helper/DockstoreConfigHelper.java
+++ b/tooltester/src/main/java/io/dockstore/tooltester/helper/DockstoreConfigHelper.java
@@ -1,0 +1,34 @@
+package io.dockstore.tooltester.helper;
+
+/**
+ * @author gluu
+ * @since 05/12/17
+ */
+public class DockstoreConfigHelper {
+    public enum CWLRUNNER {
+        CWLTOOL,
+        RABIX
+    }
+    private static String baseConfig(String url) {
+        return "token: test \\nserver-url: " + url;
+    }
+    private static String cwltoolConfig(String url) {
+        return baseConfig(url);
+    }
+
+    private static String rabixConfig(String url) {
+        return baseConfig(url) + "\\ncwlrunner: bunny";
+    }
+
+    public static String getConfig(String url, CWLRUNNER runner) {
+        switch (runner) {
+        case CWLTOOL:
+            return cwltoolConfig(url);
+        case RABIX:
+            return rabixConfig(url);
+        default:
+            ExceptionHandler.errorMessage("Unknown runner.", ExceptionHandler.CLIENT_ERROR);
+        }
+        return null;
+    }
+}

--- a/tooltester/src/main/resources/PipelineTest.groovy
+++ b/tooltester/src/main/resources/PipelineTest.groovy
@@ -26,6 +26,7 @@ def transformIntoStep(url, tag, descriptor, parameter, entryType, synapseCache) 
                 sh 'pip list'
                 sh 'dockstore plugin list --script || true'
                 sh 'git clone ${URL} target'
+                sh 'echo -e "${Config}" > ~/.dockstore/config'
                 dir('target') {
                     sh 'git checkout ${Tag}'
                     if (synapseCache != "") {

--- a/tooltester/src/main/resources/jenkinsPlaybook.yml
+++ b/tooltester/src/main/resources/jenkinsPlaybook.yml
@@ -85,11 +85,4 @@
       become: yes
       apt:
         name: s3cmd
-    - name: Write dockstore config file
-      become: yes
-      become_user: jenkins
-      copy:
-        content: "token: test \nserver-url: https://staging.dockstore.org:8443"
-        dest: "{{jenkins_home.stdout}}/.dockstore/config"
-        mode: 0555
                                                                                                                                                                        35,7          Top

--- a/tooltester/src/test/java/io/dockstore/tooltester/helper/DockstoreConfigHelperTest.java
+++ b/tooltester/src/test/java/io/dockstore/tooltester/helper/DockstoreConfigHelperTest.java
@@ -1,0 +1,25 @@
+package io.dockstore.tooltester.helper;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+/**
+ * @author gluu
+ * @since 05/12/17
+ */
+public class DockstoreConfigHelperTest {
+    @Test
+    public void testCwltoolConfig() {
+        final String url = "https://staging.dockstore.org:8443";
+        String cwltoolConfig = DockstoreConfigHelper.getConfig(url, DockstoreConfigHelper.CWLRUNNER.CWLTOOL);
+        assertEquals(cwltoolConfig, "token: test \\nserver-url: https://staging.dockstore.org:8443");
+    }
+
+    @Test
+    public void testRabixConfig() {
+        final String url = "https://staging.dockstore.org:8443";
+        String rabixConfig = DockstoreConfigHelper.getConfig(url, DockstoreConfigHelper.CWLRUNNER.RABIX);
+        assertEquals(rabixConfig, "token: test \\nserver-url: https://staging.dockstore.org:8443\\ncwlrunner: bunny");
+    }
+}

--- a/tooltester/src/test/java/io/dockstore/tooltester/helper/DockstoreConfigHelperTest.java
+++ b/tooltester/src/test/java/io/dockstore/tooltester/helper/DockstoreConfigHelperTest.java
@@ -1,6 +1,8 @@
 package io.dockstore.tooltester.helper;
 
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.contrib.java.lang.system.ExpectedSystemExit;
 
 import static org.junit.Assert.*;
 
@@ -9,17 +11,27 @@ import static org.junit.Assert.*;
  * @since 05/12/17
  */
 public class DockstoreConfigHelperTest {
+    @Rule
+    public final ExpectedSystemExit exit = ExpectedSystemExit.none();
+
     @Test
     public void testCwltoolConfig() {
         final String url = "https://staging.dockstore.org:8443";
-        String cwltoolConfig = DockstoreConfigHelper.getConfig(url, DockstoreConfigHelper.CWLRUNNER.CWLTOOL);
+        String cwltoolConfig = DockstoreConfigHelper.getConfig(url, "cwltool");
         assertEquals(cwltoolConfig, "token: test \\nserver-url: https://staging.dockstore.org:8443");
     }
 
     @Test
     public void testRabixConfig() {
         final String url = "https://staging.dockstore.org:8443";
-        String rabixConfig = DockstoreConfigHelper.getConfig(url, DockstoreConfigHelper.CWLRUNNER.RABIX);
+        String rabixConfig = DockstoreConfigHelper.getConfig(url, "bunny");
         assertEquals(rabixConfig, "token: test \\nserver-url: https://staging.dockstore.org:8443\\ncwlrunner: bunny");
+    }
+
+    @Test
+    public void testPotatoConfig() {
+        final String url = "https://staging.dockstore.org:8443";
+        exit.expectSystemExitWithStatus(ExceptionHandler.CLIENT_ERROR);
+        String rabixConfig = DockstoreConfigHelper.getConfig(url, "potato");
     }
 }


### PR DESCRIPTION
Create dockstore config file from tooltester's config file which will then be passed as a parameter to Jenkins.  Playbook creating the config file is no longer needed.

The config file being created means tooltester will handle 2 things: the server-url and runner.

This also checks if the tool/workflow has a descriptor/parameter file before trying to run it.